### PR TITLE
Check index when checking for consecutives underscores and hyphens

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -22,7 +22,7 @@ export function ytid(){
       }
 
       // Preventing two consecutive underscores and hyphens
-      if ((selectedCharacter === '_' && id[i - 1] === '_') || (selectedCharacter === '-' && id[i - 1] === '-')) {
+      if (i >= 1 && ((selectedCharacter === '_' && id[i - 1] === '_') || (selectedCharacter === '-' && id[i - 1] === '-'))) {
         i--;
         continue;
       }


### PR DESCRIPTION
The index needs to be at least 1 when checking for two consecutive underscores or hyphens. Otherwise, if the 0th character is a underscore or hyphen, `id[i - 1]` fails.